### PR TITLE
weather_server.py with `FastMCP` to leverage the new addition to MCP Python SDK and lower the amt of code

### DIFF
--- a/src/mcp_weather_service/weather_server.py
+++ b/src/mcp_weather_service/weather_server.py
@@ -1,3 +1,4 @@
+# TODO: use mcp.server.FastMCP
 import logging
 import uvicorn
 from starlette.applications import Starlette


### PR DESCRIPTION
have you considered using `mcp.server.FastMCP`? Something along the lines of:

```python
from mcp.server import FastMCP


# Initialize FastMCP server
mcp = FastMCP(name="weather")


@mcp.tool()
async def get_forecast(city: str, state: str) -> str:
    """Get weather forecast for a city in a state.

    Args:
        city: City name
        state: Two-letter US state code (e.g. CA, NY)
    """
    # TODO: replace w/ actual forecast
    return """
Now:
Temperature: 42° F
Wind: 10 mph N
Forecast: Mostly sunny, with a high near 42. North wind around 10 mph.
"""


if __name__ == "__main__":
    # Initialize and run the server
    mcp.run(transport='sse')
```

It got added to the MCP Python SDK sometime after your code. I see that it already does a lot of this.